### PR TITLE
Fixed passing post content to request

### DIFF
--- a/src/Lib/Connector/KohanaConnector.php
+++ b/src/Lib/Connector/KohanaConnector.php
@@ -47,9 +47,17 @@ class KohanaConnector extends Client {
 			{
 				$kohanaRequest->query($request->getParameters());
 			}
+
 			if (strtoupper($request->getMethod()) == 'POST')
 			{
-				$kohanaRequest->post($request->getParameters());
+				if ($request->getContent() !== NULL)
+				{
+					$kohanaRequest->body($request->getContent());
+				}
+				else
+				{
+					$kohanaRequest->post($request->getParameters());
+				}
 			}
 
 			$kohanaRequest->cookie($_COOKIE);


### PR DESCRIPTION
When calling an endpoint such as an API that only accepts json from php://input the current connector did not forward the content along.

This commit fixes that issue